### PR TITLE
Hide about link when About page is unnecessary

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -152,6 +152,8 @@ module TTL2HTML
       labels = shapes2labels(shapes)
       versions = extract_versions
       toplevel = extract_toplevel
+      about_required = template.find_template_path("about.html") || !shapes.empty? || !versions.empty? || !toplevel.empty?
+      about_file = (@config[:about_file] || "about.html") if about_required
       @config[:labels_with_class] ||= {}
       labels.each do |klass, props|
         props.each do |property, label|
@@ -188,6 +190,7 @@ module TTL2HTML
         if template.find_template_path("_default.html.erb")
           param[:additional_content] = template.to_html_raw("_default.html.erb", param)
         end
+        param[:about_file] = about_file if about_required
         template.output_to(file, param)
       end
       index_html = "index.html"
@@ -226,14 +229,16 @@ module TTL2HTML
           end
           param[:output_file] = index_html
           param[:index_list] = template.to_html_raw("index-list.html.erb", param)
+          param[:about_file] = about_file if about_required
           template.output_to(index_html, param)
         end
       end
-      if template.find_template_path("about.html") or shapes.size > 0 or versions.size > 0 or toplevel.size > 0
-        about_html = @config[:about_file] || "about.html"
+      if about_required
+        about_html = about_file
         about_html =  File.join(@config[:output_dir], about_html) if @config[:output_dir]
         template = Template.new("about.html.erb", @config)
         param = @config.dup
+        param[:about_file] = about_file
         param[:content] = template.to_html_raw("about.html", {}) if template.find_template_path("about.html")
         param[:data_global] = @data
         param[:versions] = versions

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -597,8 +597,23 @@ RSpec.describe TTL2HTML::App do
       expect(html).to have_css("footer p", text: "Dataset Admin")
       expect(html).to have_css("footer p", text: "© 2021")
     end
-    it "should link to home and about" do
+    it "should link to home without about when about page is unnecessary" do
       @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example.yml"))
+      @ttl2html.load_turtle(File.join(spec_base_dir, "example/example.ttl"))
+      @ttl2html.output_html_files
+      cont = open("/tmp/html/index.html"){|io| io.read }
+      html = Capybara.string cont
+      expect(html).to have_css("nav.navbar a.nav-link[href='./']", text: "Home")
+      expect(html).not_to have_css("nav.navbar a.nav-link[href='about.html']", text: "About")
+      expect(html).not_to have_css("div.jumbotron a[href='about.html']", text: "About")
+      cont = open("/tmp/html/a/b.html"){|io| io.read }
+      html = Capybara.string cont
+      expect(html).to have_css("nav.navbar a.nav-link[href='../']", text: "Home")
+      expect(html).not_to have_css("nav.navbar a.nav-link[href='../about.html']", text: "About")
+    end
+
+    it "should link to home and about when about page is generated" do
+      @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example_about.yml"))
       @ttl2html.load_turtle(File.join(spec_base_dir, "example/example.ttl"))
       @ttl2html.output_html_files
       cont = open("/tmp/html/index.html"){|io| io.read }

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -8,7 +8,9 @@
         <div class="description"><%= param[:description] %></div>
         <%- end -%>
         <p><i class="bi bi-link-45deg"></i> <a href="<%=h param[:base_uri] %>"><%=h param[:base_uri] %></a></p>
-        <p><a class="btn btn-info" href="<%=h relative_path(param[:about_file] || "about.html") %>"><%=h t("about.title", title: param[:site_title]) %> &raquo;</a></p>
+        <%- if param[:about_file] -%>
+        <p><a class="btn btn-info" href="<%=h relative_path(param[:about_file]) %>"><%=h t("about.title", title: param[:site_title]) %> &raquo;</a></p>
+        <%- end -%>
       </div>
     </div>
     <div class="container">
@@ -20,8 +22,8 @@
           <dl>
             <%= format_version_info(param[:versions].last) %>
           </dl>
-          <%- if param[:versions].size > 1 -%>
-          <p><a href="about#versions">&raquo; <%=h t("index.past-versions") %></a></p>
+          <%- if param[:about_file] and param[:versions].size > 1 -%>
+          <p><a href="<%=h relative_path(param[:about_file]) %>#versions">&raquo; <%=h t("index.past-versions") %></a></p>
           <%- end -%>
           <%- if param[:toplevel] and not param[:toplevel][:license].empty? -%>
           <p class="license">

--- a/templates/layout.html.erb
+++ b/templates/layout.html.erb
@@ -63,9 +63,11 @@
           <li class="nav-item<%= ' active' if @template == "index.html.erb" %>">
             <a class="nav-link" href="<%=h relative_path_uri(param[:base_uri]) %>">Home</a>
           </li>
+          <%- if param[:about_file] -%>
           <li class="nav-item<%= ' active' if @template == "about.html.erb" %>">
-            <a class="nav-link" href="<%=h relative_path(param[:about_file] || "about.html") %>">About</a>
+            <a class="nav-link" href="<%=h relative_path(param[:about_file]) %>">About</a>
           </li>
+          <%- end -%>
           <%- if param[:additional_link] -%>
             <%- param[:additional_link].each do |link| -%>
             <li class="nav-item"><a class="nav-link" href="<%=h link["href"] %>"><%=h link["label"] %></a></li>


### PR DESCRIPTION
## Summary
- Only generate and link to About page when dataset or templates require it
- Show About navigation button and index link only if About page exists
- Cover both cases in specs: with and without About page

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: rspec not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68c23887cefc833280da4cccfd6db9cc