### PR TITLE
Harden output path containment checks

### DIFF
--- a/lib/ttl2html/util.rb
+++ b/lib/ttl2html/util.rb
@@ -44,20 +44,20 @@ module TTL2HTML
       path
     end
     def safe_output_path(file)
-      if @config[:output_dir]
-        base = File.expand_path(@config[:output_dir])
-        target = File.expand_path(file)
-        unless target.start_with?(base)
+      base = if @config[:output_dir]
+               File.expand_path(@config[:output_dir])
+             else
+               File.expand_path(".")
+             end
+      target = File.expand_path(file)
+
+      unless target == base || target.start_with?(base + File::SEPARATOR)
+        if @config[:output_dir]
           warn "Attempting to write outside of output_dir: #{file}"
-          return false
-        end
-      else
-        base = File.expand_path(".")
-        target = File.expand_path(file)
-        unless target.start_with?(base)
+        else
           warn "Attempting to write outside of current directory: #{file}"
-          return false
         end
+        return false
       end
       file
     end

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -115,6 +115,10 @@ RSpec.describe TTL2HTML::App do
       #puts cont
       expect(html).to have_link("test title", href: "a/")
     end
+    it "should block writes outside output_dir with matching prefix" do
+      @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example.yml"))
+      expect(@ttl2html.safe_output_path("/tmp/html_evil/attack.html")).to be false
+    end
     it "should respect output dir" do
       @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example.yml"))
       @ttl2html.load_turtle(File.join(spec_base_dir, "example/example.ttl"))


### PR DESCRIPTION
### Motivation
- The code previously allowed filenames derived from RDF subjects to escape the configured `output_dir` because containment was checked with a simple prefix test, which can be bypassed by sibling-path prefixes like `/tmp/html_evil` when base is `/tmp/html`.
- Prevent writing or truncating files outside the intended output root by enforcing stricter path containment checks before writing output files.

### Description
- Tighten `safe_output_path` in `lib/ttl2html/util.rb` to compute `base = File.expand_path(@config[:output_dir])` (or `.` when not set) and `target = File.expand_path(file)`, and require `target == base` or `target.start_with?(base + File::SEPARATOR)` to be allowed; otherwise emit the existing warning and return `false`.
- Preserve the previous warning messages for `output_dir` and current-directory modes when a write is rejected.
- Add a regression spec in `spec/ttl2html_spec.rb` that asserts `safe_output_path("/tmp/html_evil/attack.html")` returns `false` to cover the prefix-bypass case.

### Testing
- Added an RSpec regression test (`spec/ttl2html_spec.rb`) to cover the prefix-bypass scenario; the test was committed alongside the fix and asserts the method returns `false` for a sibling-prefix path.
- Attempted to run the specific regression test with `bundle exec rspec spec/ttl2html_spec.rb -e "should block writes outside output_dir with matching prefix"`, but the run failed in this environment due to missing Bundler/RSpec executables: `bundler: command not found: rspec`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f38b908e1883328ef97acb22e1da6c)