### PR TITLE
Harden cleanup path validation against traversal

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -664,25 +664,30 @@ module TTL2HTML
         File.unlink html_file if File.exist? html_file
         ttl_file = uri_mapping_to_path(uri, @config, ".ttl")
         ttl_file = File.join(@config[:output_dir], ttl_file) if @config[:output_dir]
+        next if not safe_output_path(ttl_file)
         File.unlink ttl_file if File.exist? ttl_file
         dir = uri.sub(@config[:base_uri], "")
         dir = File.join(@config[:output_dir], dir) if @config[:output_dir]
+        next if not safe_output_path(dir)
         dirs << dir
       end
       index_html = "index.html"
       index_html = File.join(@config[:output_dir], "index.html") if @config[:output_dir]
-      if @config[:top_class] and File.exist? index_html
+      if @config[:top_class] and safe_output_path(index_html) and File.exist? index_html
         File.unlink index_html
       end
       about_html = (@config[:about_file] || "about.html")
       about_html = File.join(@config[:output_dir], about_html) if @config[:output_dir]
-      File.unlink about_html if File.exist? about_html
+      if safe_output_path(about_html) and File.exist? about_html
+        File.unlink about_html
+      end
 
       dirs = dirs.uniq.sort_by{|e| -(e.size) }
       #p dirs
       dirs.each do |dir|
         next if dir == "." # failsafe...
         next if dir == @config[:output_dir] # failsafe...
+        next if not safe_output_path(dir)
         FileUtils.remove_entry_secure(dir) if File.exist? dir
       end
     end

--- a/lib/ttl2html/util.rb
+++ b/lib/ttl2html/util.rb
@@ -44,20 +44,15 @@ module TTL2HTML
       path
     end
     def safe_output_path(file)
-      if @config[:output_dir]
-        base = File.expand_path(@config[:output_dir])
-        target = File.expand_path(file)
-        unless target.start_with?(base)
-          warn "Attempting to write outside of output_dir: #{file}"
-          return false
-        end
-      else
-        base = File.expand_path(".")
-        target = File.expand_path(file)
-        unless target.start_with?(base)
-          warn "Attempting to write outside of current directory: #{file}"
-          return false
-        end
+      base = if @config[:output_dir]
+               File.expand_path(@config[:output_dir])
+             else
+               File.expand_path(".")
+             end
+      target = File.expand_path(file)
+      unless target == base || target.start_with?(base + File::SEPARATOR)
+        warn "Attempting to write outside of output_dir: #{file}"
+        return false
       end
       file
     end


### PR DESCRIPTION
### Motivation
- The `cleanup` flow derived filesystem paths from attacker-controlled RDF subject URIs and could call `File.unlink`/`FileUtils.remove_entry_secure` on traversal or absolute paths outside the intended `output_dir`, enabling deletion of files outside the output tree.
- The goal is to prevent prefix-bypass and path-traversal attacks by ensuring every deletion target is canonicalized and contained inside the configured output base before any destructive operation.

### Description
- Tighten `safe_output_path` to compute canonical `base` and `target` via `File.expand_path` and require `target == base` or `target.start_with?(base + File::SEPARATOR)` to avoid prefix-bypass (e.g. `/tmp/out2` vs `/tmp/out`).
- In `cleanup`, validate candidate `.ttl` files with `safe_output_path` before unlinking them.
- In `cleanup`, validate candidate directory paths and skip adding/removing directories that fail `safe_output_path` checks.
- In `cleanup`, check `index.html` and `about.html` with `safe_output_path` before unlinking to avoid deleting auxiliary files outside the output tree.

### Testing
- Ran `ruby -c lib/ttl2html.rb` and it returned `Syntax OK`.
- Ran `ruby -c lib/ttl2html/util.rb` and it returned `Syntax OK`.
- Attempted `bundle exec rspec spec/ttl2html_spec.rb` but it could not run in this environment because the `rspec` executable was not installed via Bundler, so spec-suite execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f38e307bf08332a0ebbf958d174a0a)