### PR TITLE
generate only the used prefixes for output_turtle_files

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -97,7 +97,11 @@ module TTL2HTML
       end
     end
     def format_uri(uri, writer = RDF::Turtle::Writer.new(nil, prefixes: @prefix))
-      writer.format_uri(RDF::URI(uri))
+      result = writer.format_uri(RDF::URI(uri))
+      if result =~ /^[a-zA-Z_][a-zA-Z0-9_\-]*:/
+        @used_prefixes << result.split(":").first
+      end
+      result
     end
     def format_turtle(subject, depth = 1, force = false)
       turtle_writer = RDF::Turtle::Writer.new(nil, prefixes: @prefix)
@@ -651,11 +655,12 @@ module TTL2HTML
         FileUtils.mkdir_p(dir) if not File.exist?(dir)
         @cache ||= {}
         @cache[:output_turtle_files] = Set.new
+        @used_prefixes = Set.new
         str = format_turtle(uri)
         str << format_turtle_inverse(uri)
         File.open(file, "w") do |io|
-          @prefix.each do |prefix, namespace|
-            io.puts "@prefix #{prefix}: <#{namespace}>."
+          @used_prefixes.each do |prefix|
+            io.puts "@prefix #{prefix}: <#{@prefix[prefix.to_sym]}>."
           end
           io.puts str.strip
         end

--- a/spec/example/example_prefix.ttl
+++ b/spec/example/example_prefix.ttl
@@ -1,10 +1,11 @@
 @prefix ex: <https://example.org/>.
+@prefix dct: <http://purl.org/dc/terms/>.
 ex:a a ex:b.
-ex:a <http://purl.org/dc/terms/title> "test title".
+ex:a dct:title "test title".
 ex:a\/b a ex:b.
 ex:a\/b ex:title "test title example".
 ex:b a ex:a.
-ex:b <http://purl.org/dc/terms/title> "title".
+ex:b dct:title "title".
 ex:b <http://www.w3.org/2000/01/rdf-schema#label> "test label".
 ex:c a ex:b.
-ex:c <http://purl.org/dc/terms/title> "test title"@ja.
+ex:c dct:title "test title"@ja.

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -1234,6 +1234,12 @@ RSpec.describe TTL2HTML::App do
         expect(reader.statements).not_to be_empty
         expect(reader.prefixes).not_to be_empty
       end
+      #puts File.read("/tmp/html/a/b.ttl")
+      RDF::Turtle::Reader.new(open("/tmp/html/a/b.ttl")) do |reader|
+        expect(reader.statements).not_to be_empty
+        expect(reader.prefixes).not_to be_empty
+        expect(reader.prefixes.size).to eq 1
+      end
     end
   end
   context "#output_files" do


### PR DESCRIPTION
## Summary

Only generate and output prefixes that are actually used in the Turtle serialization.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)

