### PR TITLE
more prefix patterns for output_turtle_files

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -98,7 +98,7 @@ module TTL2HTML
     end
     def format_uri(uri, writer = RDF::Turtle::Writer.new(nil, prefixes: @prefix))
       result = writer.format_uri(RDF::URI(uri))
-      if result =~ /^[a-zA-Z_][a-zA-Z0-9_\-]*:/
+      if result =~ /^#{RDF::Turtle::Terminals::PN_PREFIX}?:/
         @used_prefixes << result.split(":").first
       end
       result
@@ -660,7 +660,11 @@ module TTL2HTML
         str << format_turtle_inverse(uri)
         File.open(file, "w") do |io|
           @used_prefixes.each do |prefix|
-            io.puts "@prefix #{prefix}: <#{@prefix[prefix.to_sym]}>."
+            if prefix.empty?
+              io.puts "@prefix : <#{@prefix[nil]}>."
+            else
+              io.puts "@prefix #{prefix}: <#{@prefix[prefix.to_sym]}>."
+            end
           end
           io.puts str.strip
         end

--- a/spec/example/example_default_prefix.ttl
+++ b/spec/example/example_default_prefix.ttl
@@ -1,0 +1,12 @@
+@prefix : <https://example.org/>.
+@prefix ex.test: <https://example.com/>.
+@prefix dct: <http://purl.org/dc/terms/>.
+:a a :b.
+:a dct:title "test title".
+:a\/b a :b.
+:a\/b ex.test:title "test title example".
+:b a :a.
+:b dct:title "title".
+:b <http://www.w3.org/2000/01/rdf-schema#label> "test label".
+:c a :b.
+:c dct:title "test title"@ja.

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -1241,6 +1241,26 @@ RSpec.describe TTL2HTML::App do
         expect(reader.prefixes.size).to eq 1
       end
     end
+    it "should support more prefix patterns for outputs" do
+      ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example", "example.yml"))
+      ttl2html.load_turtle(File.join(spec_base_dir, "example", "example_default_prefix.ttl"))
+      ttl2html.output_turtle_files
+      expect(File).to exist("/tmp/html/a.ttl")
+      #puts File.read("/tmp/html/a.ttl")
+      RDF::Turtle::Reader.new(open("/tmp/html/a.ttl")) do |reader|
+        expect(reader.statements).not_to be_empty
+        expect(reader.prefixes).not_to be_empty
+        expect(reader.prefixes).to have_key nil
+        expect(reader.prefixes[nil]).to eq RDF::URI("https://example.org/")
+      end
+      #puts File.read("/tmp/html/a/b.ttl")
+      RDF::Turtle::Reader.new(open("/tmp/html/a/b.ttl")) do |reader|
+        expect(reader.statements).not_to be_empty
+        expect(reader.prefixes).not_to be_empty
+        expect(reader.prefixes).to have_key nil
+        expect(reader.prefixes[nil]).to eq RDF::URI("https://example.org/")
+      end
+    end
   end
   context "#output_files" do
     ttl2html = nil


### PR DESCRIPTION
## Summary

Support for more prefix patterns on output_turtle_files. e.g. default prefix and ".".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)
