### PR TITLE
add literal datatype namespace for used_prefixes

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -125,11 +125,10 @@ module TTL2HTML
           elsif RDF::URI::IRI =~ object.to_s
             format_uri(object, turtle_writer)
           else
-            literal_s = turtle_writer.format_literal(object)
-            if literal_s =~ /\^\^(#{RDF::Turtle::Terminals::PN_PREFIX})?:.*?$/
-              @used_prefixes << $1
+            if object.respond_to?(:datatype) and object.datatype?
+              datatype = format_uri(object.datatype) # to add @used_prefixes
             end
-            literal_s
+            turtle_writer.format_literal(object)
           end
         end.join(", ")
         str

--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -125,7 +125,11 @@ module TTL2HTML
           elsif RDF::URI::IRI =~ object.to_s
             format_uri(object, turtle_writer)
           else
-            turtle_writer.format_literal(object)
+            literal_s = turtle_writer.format_literal(object)
+            if literal_s =~ /\^\^(#{RDF::Turtle::Terminals::PN_PREFIX})?:.*?$/
+              @used_prefixes << $1
+            end
+            literal_s
           end
         end.join(", ")
         str

--- a/spec/example/example_xsd_datatype.ttl
+++ b/spec/example/example_xsd_datatype.ttl
@@ -1,6 +1,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 <https://example.org/a> a <https://example.org/b>.
-<https://example.org/a> <http://purl.org/dc/terms/title> "test title".
+<https://example.org/a> <http://purl.org/dc/terms/title> "test title ^^test:title".
 <https://example.org/a> <http://purl.org/dc/terms/issued> "2025"^^<http://www.w3.org/2001/XMLSchema#gYear>.
 <https://example.org/a/b> a <https://example.org/b>.
 <https://example.org/a/b> <http://example.org/title> "test title example".

--- a/spec/example/example_xsd_datatype.ttl
+++ b/spec/example/example_xsd_datatype.ttl
@@ -1,0 +1,11 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+<https://example.org/a> a <https://example.org/b>.
+<https://example.org/a> <http://purl.org/dc/terms/title> "test title".
+<https://example.org/a> <http://purl.org/dc/terms/issued> "2025"^^<http://www.w3.org/2001/XMLSchema#gYear>.
+<https://example.org/a/b> a <https://example.org/b>.
+<https://example.org/a/b> <http://example.org/title> "test title example".
+<https://example.org/b> a <https://example.org/a>.
+<https://example.org/b> <http://purl.org/dc/terms/title> "title".
+<https://example.org/b> <http://www.w3.org/2000/01/rdf-schema#label> "test label".
+<https://example.org/c> a <https://example.org/b>.
+<https://example.org/c> <http://purl.org/dc/terms/title> "test title"@ja.

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -1264,7 +1264,9 @@ RSpec.describe TTL2HTML::App do
     it "should output xsd prefix for xsd-ed datatype literals" do
       ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example", "example.yml"))
       ttl2html.load_turtle(File.join(spec_base_dir, "example", "example_xsd_datatype.ttl"))
-      ttl2html.output_turtle_files
+      expect {
+        ttl2html.output_turtle_files
+      }.not_to raise_error
       #puts File.read("/tmp/html/a.ttl")
       RDF::Turtle::Reader.open("/tmp/html/a.ttl", validate: true) do |reader|
         expect {

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -1261,6 +1261,17 @@ RSpec.describe TTL2HTML::App do
         expect(reader.prefixes[nil]).to eq RDF::URI("https://example.org/")
       end
     end
+    it "should output xsd prefix for xsd-ed datatype literals" do
+      ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example", "example.yml"))
+      ttl2html.load_turtle(File.join(spec_base_dir, "example", "example_xsd_datatype.ttl"))
+      ttl2html.output_turtle_files
+      #puts File.read("/tmp/html/a.ttl")
+      RDF::Turtle::Reader.open("/tmp/html/a.ttl", validate: true) do |reader|
+        expect {
+          expect(reader.statements).not_to be_empty
+        }.not_to raise_error
+      end
+    end
   end
   context "#output_files" do
     ttl2html = nil


### PR DESCRIPTION
## Summary

Fix a bug for syntax error in turtle output, where the xsd datatype namespace is used but not in prefix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)

## Further comments

Issue #243 