### PR TITLE
Avoid mutating strings returned by RDF::Turtle::Writer

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -106,6 +106,7 @@ module TTL2HTML
       result = writer.format_uri(RDF::URI(uri))
       if result =~ /^#{RDF::Turtle::Terminals::PN_PREFIX}?:/
         @used_prefixes << result.split(":").first
+        #STDERR.puts [uri, @used_prefixes].inspect
       end
       result
     end
@@ -119,7 +120,8 @@ module TTL2HTML
         result << format_uri(subject) << "\n#{"  "*depth}"
       end
       result << @data[subject.to_s].keys.sort.map do |predicate|
-        str = format_uri(predicate, turtle_writer) << " "
+        str = format_uri(predicate, turtle_writer).dup
+        str << " "
         #p [subject, predicate, @data[subject.to_s][predicate]]
         str << @data[subject.to_s][predicate].sort_by do |object|
           #p [subject, predicate, object, depth]

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -1332,6 +1332,31 @@ RSpec.describe TTL2HTML::App do
       expect(labels["https://example.org/Item"]["https://example.org/b"].first).to eq "Foo"
     end
   end
+  context "#format_turtle" do
+    it "does not mutate string returned by format_uri" do
+      ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example.yml"))
+      ttl2html.instance_variable_set(:@data, {
+        "https://example.org/a" => {
+          "https://example.org/p" => [
+            RDF::Literal.new("1"),
+            RDF::Literal.new("2")
+          ],
+          "https://example.org/q" => [
+            RDF::Literal.new("3")
+          ]
+        }
+      })
+      ttl2html.instance_variable_set(:@cache, { output_turtle_files: Set.new })
+      ttl2html.instance_variable_set(:@used_prefixes, Set.new)
+      ttl2html.instance_variable_set(:@prefix, {})
+      shared = +"ex:p"
+      allow(ttl2html).to receive(:format_uri).and_return(shared)
+      turtle = ttl2html.format_turtle("https://example.org/a")
+      #puts turtle
+      expect(turtle).not_to include('"1", "2" "3"')
+      expect(shared).to eq("ex:p")
+    end
+  end
 end
 
 RSpec.describe "bin/ttl2html" do


### PR DESCRIPTION
## Summary

- Avoid mutating strings returned by `RDF::Turtle::Writer` in `format_turtle`
- Prevent previous blank node values from leaking into subsequent Turtle output-
-  Add a regression test to ensure formatted URI strings are not mutated

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)
