### PR TITLE
fix a bug with relative path on output_dir

### DIFF
--- a/lib/ttl2html/template.rb
+++ b/lib/ttl2html/template.rb
@@ -141,22 +141,15 @@ module TTL2HTML
       else
         dest.sub!(/^\/+/, "")
         #p [:relative_path, src, dest]
-        if @param[:output_dir]
-          # src is a relative path from the current working directory and may already
-          # include `output_dir` when `output_dir` is configured as a relative path.
-          output_dir = Pathname.new(@param[:output_dir]).expand_path
-          src_path = Pathname.new(src)
-          src_path = output_dir.join(src_path) unless src_path.absolute?
-          src = src_path.expand_path.relative_path_from(output_dir)
-        else
-          src = Pathname.new(src).expand_path.relative_path_from(Pathname.pwd)
-        end
-        path = Pathname(dest).relative_path_from(src.dirname)
-        if @param[:output_dir] and File.directory?(File.join(@param[:output_dir], path))
-          path = path.to_s + "/"
-        elsif File.directory?(path)
-          path = path.to_s + "/"
-        end
+        # src is always passed as an absolute path.
+        base_dir = Pathname.pwd
+        base_dir = Pathname.new(@param[:output_dir]).expand_path if @param[:output_dir]
+        # src is always passed as an absolute path, but normalize it to remove
+        # any "." or ".." components before calling relative_path_from.
+        src_path = Pathname.new(src).expand_path
+        src_relative = src_path.relative_path_from(base_dir)
+        path = Pathname.new(dest).relative_path_from(src_relative.dirname)
+        path = "#{path}/" if base_dir.join(dest).cleanpath.directory?
       end
       #p [ :relative_path, path, dest, src ]
       path

--- a/lib/ttl2html/template.rb
+++ b/lib/ttl2html/template.rb
@@ -142,11 +142,14 @@ module TTL2HTML
         dest.sub!(/^\/+/, "")
         #p [:relative_path, src, dest]
         if @param[:output_dir]
-          src = Pathname.new(src).relative_path_from(Pathname.new(@param[:output_dir]))
+          output_dir = Pathname.new(@param[:output_dir]).expand_path
+          src_path = Pathname.new(src)
+          src_path = output_dir.join(src_path) unless src_path.absolute?
+          src = src_path.expand_path.relative_path_from(output_dir)
         else
-          src = Pathname.new(File.expand_path(src)).relative_path_from(Pathname.new(File.expand_path(".")))
+          src = Pathname.new(src).expand_path.relative_path_from(Pathname.pwd)
         end
-        path = Pathname(dest).relative_path_from(Pathname(File.dirname src))
+        path = Pathname(dest).relative_path_from(src.dirname)
         if @param[:output_dir] and File.directory?(File.join(@param[:output_dir], path))
           path = path.to_s + "/"
         elsif File.directory?(path)

--- a/lib/ttl2html/template.rb
+++ b/lib/ttl2html/template.rb
@@ -142,6 +142,8 @@ module TTL2HTML
         dest.sub!(/^\/+/, "")
         #p [:relative_path, src, dest]
         if @param[:output_dir]
+          # src is a relative path from the current working directory and may already
+          # include `output_dir` when `output_dir` is configured as a relative path.
           output_dir = Pathname.new(@param[:output_dir]).expand_path
           src_path = Pathname.new(src)
           src_path = output_dir.join(src_path) unless src_path.absolute?

--- a/spec/ttl2html_template_spec.rb
+++ b/spec/ttl2html_template_spec.rb
@@ -15,33 +15,22 @@ RSpec.describe TTL2HTML::Template do
   context "#relative_path_uri" do
     it "should generate relative path" do
       tmpl = TTL2HTML::Template.new("", output_file: "a.html", base_uri: "http://example.org/")
-      path = tmpl.relative_path_uri("a.html", "http://example.org/a", "http://example.org/")
+      a_html = File.expand_path("a.html")
+      path = tmpl.relative_path_uri(a_html, "http://example.org/a", "http://example.org/")
       expect(path).to eq Pathname.new("a")
       path = tmpl.relative_path_uri("http://example.org/a", "http://example.com/a", "http://example.org/")
       expect(path).to eq "http://example.com/a"
     end
-    it "should generate relative path with output_dir" do
-      tmpl = TTL2HTML::Template.new("", output_dir: "/tmp/output", base_uri: "http://example.org/")
-      path = tmpl.relative_path_uri("a.html", "http://example.org/a", "http://example.org/")
-      expect(path).to eq Pathname.new("a")
-    end
   end
   context "#relative_path" do
-      it "handles a relative src that already includes output_dir" do
-      tmpl = TTL2HTML::Template.new("", base_uri: "http://example.org/")
+    it "handles an absolute src with a relative output_dir" do
       param = {
+        base_uri: "http://example.org/",
         output_dir: "out",
-        output_file: "out/index.html"
       }
-      expect(tmpl.relative_path(param[:output_file], "a.html")).to eq Pathname.new("../a.html")
-    end
-    it "does not prepend a relative output_dir twice" do
-      tmpl = TTL2HTML::Template.new("", base_uri: "http://example.org/")
-      param = {
-        output_dir: "out",
-        output_file: "out/sub/index.html"
-      }
-      expect(tmpl.relative_path(param[:output_file], "a.html")).to eq Pathname.new("../../a.html")
+      tmpl = TTL2HTML::Template.new("", param)
+      src = File.expand_path("out/index.html")
+      expect(tmpl.relative_path(src, "about.html").to_s).to eq("about.html")
     end
   end
   context "find_template" do

--- a/spec/ttl2html_template_spec.rb
+++ b/spec/ttl2html_template_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe TTL2HTML::Template do
       path = tmpl.relative_path_uri("http://example.org/a", "http://example.com/a", "http://example.org/")
       expect(path).to eq "http://example.com/a"
     end
+    it "should generate relative path with output_dir" do
+      tmpl = TTL2HTML::Template.new("", output_dir: "/tmp/output", base_uri: "http://example.org/")
+      path = tmpl.relative_path_uri("a.html", "http://example.org/a", "http://example.org/")
+      expect(path).to eq Pathname.new("a")
+    end
   end
   context "find_template" do
     it "should find proper template file" do

--- a/spec/ttl2html_template_spec.rb
+++ b/spec/ttl2html_template_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe TTL2HTML::Template do
       expect(path).to eq Pathname.new("a")
     end
   end
+  context "#relative_path" do
+      it "handles a relative src that already includes output_dir" do
+      tmpl = TTL2HTML::Template.new("", base_uri: "http://example.org/")
+      param = {
+        output_dir: "out",
+        output_file: "out/index.html"
+      }
+      expect(tmpl.relative_path(param[:output_file], "a.html")).to eq Pathname.new("../a.html")
+    end
+    it "does not prepend a relative output_dir twice" do
+      tmpl = TTL2HTML::Template.new("", base_uri: "http://example.org/")
+      param = {
+        output_dir: "out",
+        output_file: "out/sub/index.html"
+      }
+      expect(tmpl.relative_path(param[:output_file], "a.html")).to eq Pathname.new("../../a.html")
+    end
+  end
   context "find_template" do
     it "should find proper template file" do
       template = TTL2HTML::Template.new("")


### PR DESCRIPTION
## Summary

Fix an error in `relative_path` when `@param[:output_dir]` is specified.

Previously, `Pathname#relative_path_from` could receive a relative src path and an absolute output_dir path, causing the following error:

different prefix: "" and "/tmp/output"

This change normalizes both paths before calculating the relative path, so that path prefixes are consistent.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)

## Further comments

The error occurred because `Pathname#relative_path_from` requires both paths to use the same path prefix. When `@param[:output_dir]` was an absolute path but `src` was relative, the calculation failed.

The fix converts the relevant paths to absolute paths before calculating the path relative to `output_dir`.
