### PR TITLE
Fix relative_path_uri on src has nil value

### DIFF
--- a/lib/ttl2html/template.rb
+++ b/lib/ttl2html/template.rb
@@ -155,6 +155,9 @@ module TTL2HTML
       path
     end
     def relative_path_uri(src, dest_uri, base_uri = @param[:base_uri])
+      # A relative link cannot be calculated without the source output file.
+      # Fall back to the original absolute URI.
+      return dest_uri unless src
       if dest_uri.start_with? base_uri
         dest = dest_uri.sub(base_uri, "")
         dest = uri_mapping_to_path(dest, @param, "")

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -1063,6 +1063,34 @@ RSpec.describe TTL2HTML::App do
       expect(File.exist?("/tmp/html/a/index.html")).to be true
     end
   end
+  describe "index-list.html.erb" do
+    let(:subject_uri) { "https://example.org/subject/1" }
+    let(:param) do
+      {
+        base_uri: "https://example.org/",
+        index_data: [
+          { subject_uri => {} }
+        ],
+        data_global: {
+          subject_uri => {
+            "http://purl.org/dc/terms/date" => ["2025"],
+            "https://w3id.org/jp-cos/subjectArea" => [RDF::Literal.new("国語", language: :ja)],
+            RDF::RDFS.label.to_s => [RDF::Literal.new("国語", language: :ja)]
+          }
+        },
+        output_file: nil
+      }
+    end
+    let(:tmpl) do
+      TTL2HTML::Template.new("", param)
+    end
+    it "renders resources even when output_file is not set" do
+      expect {
+        cont = tmpl.to_html_raw("index-list.html.erb", param)
+        #puts cont
+      }.not_to raise_error
+    end
+  end
   context "#output_turtle_files" do
     ttl2html = nil
     after(:each) do


### PR DESCRIPTION
## Summary

Handle cases where relative_path_uri is called with a nil source path.

Some templates, such as `index-list.html.erb`, may call `format_object` without an `output_file` in the parameter context. In that case, `relative_path_uri` receives `nil` as `src`, and `relative_path` raises a `TypeError` when initializing `Pathname`.

This change falls back to the original absolute URI when src is not available, because a relative link cannot be calculated without the source output-file path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)
