### PR TITLE
fix a markup bug with multiple aria-current attr have page values

### DIFF
--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -817,6 +817,7 @@ RSpec.describe TTL2HTML::App do
       expect(html).to have_css("nav ol.breadcrumb a", text: /^test title$/)
       expect(html).to have_css("nav ol.breadcrumb a", text: /^test title 2$/)
       expect(html).to have_css("nav ol.breadcrumb li.active", text: "test title 3")
+      expect(html).to have_css('nav ol.breadcrumb [aria-current="page"]', count: 1)
     end
     it "should output breadcrumbs with inverse property settings" do
       @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example_breadcrumbs_inverse.yml"))

--- a/templates/default.html.erb
+++ b/templates/default.html.erb
@@ -77,7 +77,11 @@
             <ol class="breadcrumb">
               <li class="breadcrumb-item"><a href="<%=h relative_path_uri(param[:output_file], param[:base_uri]) %>"><i class="bi bi-house-door-fill"></i> Home</a></li>
               <%- param[:breadcrumbs_items].reverse.each_with_index do |e, i| -%>
-                <li class="breadcrumb-item<%= ' active' if i == param[:breadcrumbs_items].size-1 %>" aria-current="page">
+                <%- if i == param[:breadcrumbs_items].size-1 -%>
+                <li class="breadcrumb-item active" aria-current="page">
+                <%- else -%>
+                <li class="breadcrumb-item">
+                <%- end -%>
                 <%- if e[:uri] -%>
                   <a href="<%=h relative_path_uri(param[:output_file], e[:uri]) %>"><%=h e[:label] %></a>
                 <%- else -%>


### PR DESCRIPTION
## Summary

Fix the breadcrumb markup so that `aria-current="page"` is applied only to the current page item.

Previously, multiple breadcrumb items were marked with `aria-current="page"`, resulting in invalid or misleading accessibility markup. This change ensures that only the active breadcrumb item is identified as the current page.

A regression test has also been added to verify that each breadcrumb contains exactly one element with `aria-current="page"`.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)
