### PR TITLE
allow multiple labels setting for breadcrum

### DIFF
--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -475,14 +475,20 @@ module TTL2HTML
     end
     def build_breadcrumbs_sub(parent, template, label_prop = nil)
       data_parent = @data[parent]
-      label = template.get_title(data_parent)
-      label = data_parent[label_prop].first if label_prop and data_parent[label_prop]
       {
         uri: parent,
-        label: label,
+        label: breadcrumb_label(data_parent, template, label_prop),
       }
     end
-
+    def breadcrumb_label(data, template, label_prop = nil)
+      default_label = template.get_title(data)
+      Array(label_prop).each do |property|
+        #p [property, data[property]]
+        values = data[property]
+        return values.first if values && !values.empty?
+      end
+      default_label
+    end
     def shapes_parse(shapes)
       shapes.each do |shape|
         target_class = @data[shape]["http://www.w3.org/ns/shacl#targetClass"]&.first

--- a/lib/ttl2html.rb
+++ b/lib/ttl2html.rb
@@ -437,8 +437,8 @@ module TTL2HTML
       data = @data[uri]
       if @config[:breadcrumbs]
         if depth == 0
-          first_label = template.get_title(data)
-          first_label = data[@config[:breadcrumbs].first["label"]].first if @config[:breadcrumbs].first["label"] and data[@config[:breadcrumbs].first["label"]]
+          label_prop = @config[:breadcrumbs].first["label"]
+          first_label = breadcrumb_label(data, template, label_prop)
           results << { label: first_label }
         end
         @config[:breadcrumbs].each do |e|

--- a/spec/example/example_breadcrumbs_labels.ttl
+++ b/spec/example/example_breadcrumbs_labels.ttl
@@ -1,0 +1,13 @@
+@prefix schema: <https://schema.org/>.
+@prefix ex: <https://example.org/>.
+ex:a schema:name "test title".
+ex:a schema:hasPart ex:chap1.
+ex:chap1 schema:name "Chapter 1".
+ex:chap1 ex:chapterName "Chap1".
+ex:chap1 schema:hasPart ex:sect1, ex:sect2.
+ex:sect1 schema:name "Section 1".
+ex:sect1 ex:sectionName "Sect1".
+ex:sect1 schema:hasPart ex:subsect1.
+ex:sect2 schema:name "Section 2".
+ex:subsect1 schema:name "Subsection 1".
+ex:subsect1 ex:subsectionName "Subsect1".

--- a/spec/example/example_breadcrumbs_labels.yml
+++ b/spec/example/example_breadcrumbs_labels.yml
@@ -1,0 +1,9 @@
+base_uri: https://example.org/
+output_dir: /tmp/html
+breadcrumbs:
+  - property: https://schema.org/hasPart
+    inverse: true
+    label:
+      - https://example.org/chapterName
+      - https://example.org/sectionName
+      - https://example.org/subsectionName

--- a/spec/ttl2html_spec.rb
+++ b/spec/ttl2html_spec.rb
@@ -863,6 +863,24 @@ RSpec.describe TTL2HTML::App do
       expect(html).to have_css("nav ol.breadcrumb")
       expect(html).to have_css("nav ol.breadcrumb a[href='../../']", text: "Home")
     end
+    it "should output breadcrumbs with multiple label properties" do
+      @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example/example_breadcrumbs_labels.yml"))
+      @ttl2html.load_turtle(File.join(spec_base_dir, "example/example_breadcrumbs_labels.ttl"))
+      @ttl2html.output_html_files
+      cont = open("/tmp/html/sect1.html"){|io| io.read }
+      html = Capybara.string cont
+      expect(html).to have_css("nav ol.breadcrumb")
+      expect(html).to have_css("nav ol.breadcrumb li.breadcrumb-item", count: 4)
+      expect(html).to have_css("nav ol.breadcrumb a", text: /^test title$/)
+      expect(html).to have_css("nav ol.breadcrumb a", text: /^Chap1$/)
+      cont = open("/tmp/html/subsect1.html"){|io| io.read }
+      html = Capybara.string cont
+      expect(html).to have_css("nav ol.breadcrumb")
+      expect(html).to have_css("nav ol.breadcrumb li.breadcrumb-item", count: 5)
+      expect(html).to have_css("nav ol.breadcrumb a", text: /^test title$/)
+      expect(html).to have_css("nav ol.breadcrumb a", text: /^Chap1$/)
+      expect(html).to have_css("nav ol.breadcrumb a", text: /^Sect1$/)
+    end
     it "should support google_analytics" do
       @ttl2html = TTL2HTML::App.new(File.join(spec_base_dir, "example", "example_analytics.yml"))
       @ttl2html.load_turtle(File.join(spec_base_dir, "example", "example.ttl"))


### PR DESCRIPTION
## Summary

Support both a single property and a list of properties in the breadcrumb `label` configuration.

When multiple label properties are configured, ttl2html now checks them in order and uses the first property that has a value. If none of the configured properties match, it falls back to the default title generated by get_title.

This keeps the existing behavior for a single label property while allowing projects to define prioritized fallback properties for breadcrumb labels.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or other updates (if none of the other choices apply)

